### PR TITLE
Changes `@typescript-eslint/naming-convention` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18414,7 +18414,7 @@
     },
     "packages/eslint-config-react": {
       "name": "@wezom/eslint-config-react",
-      "version": "3.0.0-beta.0",
+      "version": "6.0.0-beta.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@wezom/eslint-config": "file:../eslint-config",
@@ -18425,7 +18425,7 @@
     },
     "packages/eslint-config-ts": {
       "name": "@wezom/eslint-config-ts",
-      "version": "4.0.0-beta.0",
+      "version": "6.0.0-beta.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.14.2",
@@ -18435,7 +18435,7 @@
     },
     "packages/eslint-config-ts-react": {
       "name": "@wezom/eslint-config-ts-react",
-      "version": "5.0.0-beta.0",
+      "version": "6.0.0-beta.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@wezom/eslint-config-react": "file:../eslint-config-react",

--- a/packages/eslint-config-ts/.eslintrc.json
+++ b/packages/eslint-config-ts/.eslintrc.json
@@ -49,32 +49,14 @@
 		"@typescript-eslint/naming-convention": [
 			"error",
 			{
-				"selector": "default",
-				"format": ["camelCase"]
-			},
-			{
-				"selector": "variable",
-				"format": ["camelCase", "PascalCase", "UPPER_CASE"],
-				"leadingUnderscore": "allow"
-			},
-			{
-				"selector": "variable",
-				"modifiers": ["destructured"],
-				"format": null
-			},
-			{
 				"selector": "function",
 				"format": ["camelCase", "PascalCase"],
 				"leadingUnderscore": "allow"
 			},
 			{
-				"selector": "parameter",
-				"format": null
-			},
-			{
 				"selector": "memberLike",
 				"modifiers": ["private"],
-				"format": ["camelCase"],
+				"format": null,
 				"leadingUnderscore": "require"
 			},
 			{

--- a/packages/eslint-config-ts/RULES.md
+++ b/packages/eslint-config-ts/RULES.md
@@ -492,32 +492,14 @@ _Value_:
 [
 	"error",
 	{
-		"selector": "default",
-		"format": ["camelCase"]
-	},
-	{
-		"selector": "variable",
-		"format": ["camelCase", "PascalCase", "UPPER_CASE"],
-		"leadingUnderscore": "allow"
-	},
-	{
-		"selector": "variable",
-		"modifiers": ["destructured"],
-		"format": null
-	},
-	{
 		"selector": "function",
 		"format": ["camelCase", "PascalCase"],
 		"leadingUnderscore": "allow"
 	},
 	{
-		"selector": "parameter",
-		"format": null
-	},
-	{
 		"selector": "memberLike",
 		"modifiers": ["private"],
-		"format": ["camelCase"],
+		"format": null,
 		"leadingUnderscore": "require"
 	},
 	{
@@ -538,19 +520,6 @@ _Usage examples_:
 🚧 Avoid
 
 ```ts
-// Variables
-
-const my_const = 7;
-
-// memberLike
-
-const obj2 = {
-	obj_prop: true,
-	obj_method(): void {
-		console.log(this.objProp);
-	}
-};
-
 // typeLike
 
 class fooBar {}
@@ -563,6 +532,13 @@ interface myInterface {
 type MY_TYPE = string;
 
 abstract class my_class {}
+
+class FooBar {
+	private PrivateField = true;
+	private privateField = true;
+	private PRIVATE_FIELD = true;
+	private private_field = true;
+}
 
 // enumMember
 
@@ -581,11 +557,15 @@ enum MySeasons {
 const myVar = 5;
 const _myTempVar = 6;
 const MY_CONST = 7;
+const my_const = 7;
 const Obj = {};
 
 // Variables destructured
 
-const obj = {};
+const obj = {
+	no_camel_case_destructured_var: true,
+	camelCased: true
+};
 const { no_camel_case_destructured_var, camelCased } = obj;
 
 // Function parameter
@@ -605,6 +585,13 @@ function foo(
 
 const obj2 = {
 	objProp: true,
+	ObjProp: true,
+	obj_prop: true,
+	OBJECT_PROP: true,
+	_pseudoPrivateField: true,
+	_PseudoPrivateField: true,
+	_PSEUDO_PRIVATE_FIELD: true,
+	_pseudo_private_field: true,
 	objMethod(): void {
 		console.log(this.objProp);
 	}
@@ -614,7 +601,10 @@ class FooBar {
 	memberProp1: string;
 	memberProp2: string;
 
-	private _memberProp3 = 'xXx';
+	private _PrivateField = true;
+	private _privateField = true;
+	private _PRIVATE_FIELD = true;
+	private _private_field = true;
 
 	constructor(argValue1: string, argValue2: string) {
 		this.memberProp1 = argValue1;
@@ -634,7 +624,7 @@ class FooBar {
 	}
 
 	private _printPrivateMember(): void {
-		console.log(this._memberProp3);
+		console.log(this._private_field);
 	}
 
 	static instanceTypeGuard(instance: any): instance is FooBar {

--- a/packages/eslint-config-ts/tests/fixtures/@typescript-eslint___naming-convention.invalid.ts
+++ b/packages/eslint-config-ts/tests/fixtures/@typescript-eslint___naming-convention.invalid.ts
@@ -1,19 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-undef */
-/* __AUTO-TEST-EXPECT-ERRORS-COUNT=10__ */
+/* __AUTO-TEST-EXPECT-ERRORS-COUNT=11__ */
 export const blank = true;
 /* __AUTO-DOC-PRINT-AFTER__ */
-// Variables
-
-const my_const = 7;
-
-// memberLike
-
-const obj2 = {
-	obj_prop: true,
-	obj_method(): void {
-		console.log(this.objProp);
-	}
-};
 
 // typeLike
 
@@ -29,6 +17,13 @@ type MY_TYPE = string;
 
 abstract class my_class {
 
+}
+
+class FooBar {
+	private PrivateField = true;
+	private privateField = true;
+	private PRIVATE_FIELD = true;
+	private private_field = true;
 }
 
 // enumMember

--- a/packages/eslint-config-ts/tests/fixtures/@typescript-eslint___naming-convention.valid.ts
+++ b/packages/eslint-config-ts/tests/fixtures/@typescript-eslint___naming-convention.valid.ts
@@ -6,11 +6,15 @@ export const blank = true;
 const myVar = 5;
 const _myTempVar = 6;
 const MY_CONST = 7;
+const my_const = 7;
 const Obj = {};
 
 // Variables destructured
 
-const obj = {};
+const obj = {
+	no_camel_case_destructured_var: true,
+	camelCased: true
+};
 const { no_camel_case_destructured_var, camelCased } = obj;
 
 // Function parameter
@@ -30,6 +34,13 @@ function foo(
 
 const obj2 = {
 	objProp: true,
+	ObjProp: true,
+	obj_prop: true,
+	OBJECT_PROP: true,
+	_pseudoPrivateField: true,
+	_PseudoPrivateField: true,
+	_PSEUDO_PRIVATE_FIELD: true,
+	_pseudo_private_field: true,
 	objMethod(): void {
 		console.log(this.objProp);
 	}
@@ -39,7 +50,10 @@ class FooBar {
 	memberProp1: string;
 	memberProp2: string;
 
-	private _memberProp3 = 'xXx';
+	private _PrivateField = true;
+	private _privateField = true;
+	private _PRIVATE_FIELD = true;
+	private _private_field = true;
 
 	constructor(argValue1: string, argValue2: string) {
 		this.memberProp1 = argValue1;
@@ -59,7 +73,7 @@ class FooBar {
 	}
 
 	private _printPrivateMember(): void {
-		console.log(this._memberProp3);
+		console.log(this._private_field);
 	}
 
 	static instanceTypeGuard(instance: any): instance is FooBar {


### PR DESCRIPTION
Relax `default`, `variables` and `parameters` format